### PR TITLE
Use pickle.HIGHEST_PROTOCOL (fix issue #8)

### DIFF
--- a/memcachepool/cache.py
+++ b/memcachepool/cache.py
@@ -57,7 +57,7 @@ class UMemcacheCache(MemcachedCache):
     # at least this makes it compatible with
     # existing data
     def serialize(self, data):
-        return pickle.dumps(data)
+        return pickle.dumps(data, pickle.HIGHEST_PROTOCOL)
 
     def unserialize(self, data):
         return pickle.loads(data)

--- a/memcachepool/tests/settings.py
+++ b/memcachepool/tests/settings.py
@@ -1,1 +1,2 @@
 ok = 1
+SECRET_KEY = 'secret'


### PR DESCRIPTION
Set pickle protocol to HIGUEST_PROTOCAL to match django standard.

ps.: Added SECRET_KEY to settings because tests were failing without that
