### PR TITLE
return on success in client:_create_client when reconnecting

### DIFF
--- a/memcachepool/client.py
+++ b/memcachepool/client.py
@@ -52,7 +52,7 @@ class Client(object):
             delay = self.reconnect_delay
             while retries < self.max_connect_retries:
                 try:
-                    self._client.connect()
+                    return self._client.connect()
                 except socket.error, exc:
                     if exc.errno == EISCONN:
                         return   # we're good


### PR DESCRIPTION
Whenever we are reconnecting and there is no socket.error exception raised on success, the code hanged in an infinite loop. So simple return should do the work here.
