### PR TITLE
Bug fixed: Add the 'key' parameter in the 'add' method.  

### DIFF
--- a/memcachepool/cache.py
+++ b/memcachepool/cache.py
@@ -143,7 +143,7 @@ class UMemcacheCache(MemcachedCache):
 
         key = self.make_key(key, version=version)
 
-        return self.call('add', value, self._get_memcache_timeout(timeout),
+        return self.call('add', key, value, self._get_memcache_timeout(timeout),
                          flag)
 
     def get(self, key, default=None, version=None):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ test_requires = ['nose']
 
 
 setup(name='django-memcached-pool',
-      version='0.5',
+      version='0.5.1',
       description='A Memcached Pool for Django',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
Hi, 

Seems that you forgot to add the `key` parameter in the `add` method. So, when I tried to use this method it threw an error:

`TypeError: argument 2 must be string or read-only buffer, not int`

So, basically I added this parameter in this call and it fixed the problem. 

Thanks, 
Edgar